### PR TITLE
Add 80% mask, 10% random in n-gram MLM

### DIFF
--- a/pretrain.py
+++ b/pretrain.py
@@ -143,7 +143,7 @@ class Preprocess4Pretrain(Pipeline):
         # For masked Language Models
         masked_tokens, masked_pos, tokens = _sample_mask(tokens, self.mask_alpha,
                                             self.mask_beta, self.max_gram,
-                                            goal_num_predict=n_pred)
+                                            goal_num_predict=n_pred, vocab_words=self.vocab_words)
 
         masked_weights = [1]*len(masked_tokens)
 


### PR DESCRIPTION
In ALBERT(Lan at el), There is not detail about 80% mask 
![image](https://user-images.githubusercontent.com/10525011/66101701-ba2b0400-e5ea-11e9-9375-5aeca1a3173e.png)

But, from n-gram masking (Joshi et al., 2019), they said about 80/10/10
>  As in BERT, we also mask 15% of the tokens in total: replacing 80% of the masked tokens with [MASK], 10% with random tokens and 10% with the original tokens. However, we perform this replacement at the span level and not for each token individually; i.e. all the tokens in a span are replaced with [MASK]or sampled tokens 
